### PR TITLE
Calling incorrect function name?

### DIFF
--- a/data/chunk_scan/functions/player.mcfunction
+++ b/data/chunk_scan/functions/player.mcfunction
@@ -3,4 +3,4 @@ execute unless predicate chunk_scan:in_the_end if block ~ 0 ~ bedrock run functi
 execute if predicate chunk_scan:in_the_end unless block ~ 255 ~ moving_piston run function chunk_scan:chunk/init
 
 execute unless predicate chunk_scan:in_the_end positioned ~-8 0 ~-8 as @e[distance=0..,type=area_effect_cloud,tag=chunk_scan.chunk,sort=nearest,limit=1] at @s run function chunk_scan:chunk/generate
-execute if predicate chunk_scan:in_the_end positioned ~-8 0 ~-8 as @e[distance=0..,type=area_effect_cloud,tag=chunk_scan.chunk,sort=nearest,limit=1] at @s run function chunk_scan:chunk_end/generate
+execute if predicate chunk_scan:in_the_end positioned ~-8 0 ~-8 as @e[distance=0..,type=area_effect_cloud,tag=chunk_scan.chunk,sort=nearest,limit=1] at @s run function chunk_scan:chunk/generate_end


### PR DESCRIPTION
Function looks to be defined in "/functions/chunk/generate_end.mcfunction" not "chunk_end/generate"

Tested working in personal and multiplayer worlds. 

Fixes the "end generates too many entities" problem (entity type=area_effect_cloud and tagged: "chunk_scan.chunk") with current workaround "/kill @e[type=minecraft:area_effect_cloud]" in a repeating command block.